### PR TITLE
Add Questionnaire/Question association editing in React SPA

### DIFF
--- a/client/src/Api.js
+++ b/client/src/Api.js
@@ -65,8 +65,12 @@ const Api = {
     },
   },
   questions: {
-    index() {
-      return instance.get('/api/questions');
+    index(questionnaireId) {
+      const options = {};
+      if (questionnaireId) {
+        options.params = { questionnaireId };
+      }
+      return instance.get('/api/questions', options);
     },
     create(data) {
       return instance.post('/api/questions', data);

--- a/client/src/Header.js
+++ b/client/src/Header.js
@@ -57,11 +57,6 @@ function Header() {
           </Link>
         </li>
         <li className={classNames('_item', { active })}>
-          <Link onClick={() => setActive(false)} to="/questions">
-            Questions
-          </Link>
-        </li>
-        <li className={classNames('_item', { active })}>
           <Link onClick={() => setActive(false)} to="/questionnaires">
             Questionnaire
           </Link>

--- a/client/src/Questionnaires/Questionnaires.js
+++ b/client/src/Questionnaires/Questionnaires.js
@@ -3,6 +3,7 @@ import { useRouteMatch, Route, Switch } from 'react-router-dom';
 import { AuthProtectedRoute } from '../AuthContext';
 import QuestionnairesList from './QuestionnairesList';
 import QuestionnaireForm from './QuestionnaireForm';
+import Questions from '../Questions';
 
 function Questionnaires() {
   const { path } = useRouteMatch();
@@ -18,6 +19,9 @@ function Questionnaires() {
       <AuthProtectedRoute path={`${path}/:id/edit`}>
         <QuestionnaireForm />
       </AuthProtectedRoute>
+      <Route path={`${path}/:id/questions`}>
+        <Questions />
+      </Route>
     </Switch>
   );
 }

--- a/client/src/Questionnaires/QuestionnairesList.js
+++ b/client/src/Questionnaires/QuestionnairesList.js
@@ -44,6 +44,9 @@ function QuestionnairesList() {
                   <Link className="btn btn-sm btn-primary me-3" to={`/questionnaires/${questionnaire.id}/edit`}>
                     Edit
                   </Link>
+                  <Link className="btn btn-sm btn-primary me-3" to={`/questionnaires/${questionnaire.id}/questions`}>
+                    Questions
+                  </Link>
                   <button onClick={() => onDelete(questionnaire)} className="btn btn-sm btn-danger">
                     Delete
                   </button>

--- a/client/src/Questions/QuestionForm.js
+++ b/client/src/Questions/QuestionForm.js
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { useHistory, useParams } from 'react-router-dom';
+import { useHistory, useLocation, useParams } from 'react-router-dom';
 import { StatusCodes } from 'http-status-codes';
 import classNames from 'classnames';
 
@@ -9,9 +9,12 @@ import ValidationError from '../ValidationError';
 
 function QuestionForm() {
   const { id } = useParams();
+  const query = new URLSearchParams(useLocation().search);
   const history = useHistory();
   const [error, setError] = useState(null);
+  const [questionnaires, setQuestionnaires] = useState([]);
   const [question, setQuestion] = useState({
+    QuestionnaireId: query.get('QuestionnaireId') || '',
     prompt: '',
     answer_type: '',
     questionnaire_type: '',
@@ -21,9 +24,19 @@ function QuestionForm() {
 
   useEffect(
     function () {
-      if (id) {
-        Api.questions.get(id).then((response) => setQuestion(response.data));
-      }
+      Api.questionnaires
+        .index()
+        .then((response) => {
+          setQuestionnaires(response.data);
+          if (id) {
+            return Api.questions.get(id);
+          }
+        })
+        .then((response) => {
+          if (response) {
+            setQuestion(response.data);
+          }
+        });
     },
     [id]
   );
@@ -57,6 +70,23 @@ function QuestionForm() {
     <main className="container">
       <h1>{id ? 'Edit' : 'New'} Question </h1>
       <form onSubmit={onSubmit}>
+        <div className="mb-3">
+          <label htmlFor="QuestionnaireId">Questionnaire</label>
+          <select
+            className={classNames('form-select', { 'is-invalid': error?.errorsFor?.('pQuestionnaireIdrompt') })}
+            id="QuestionnaireId"
+            name="QuestionnaireId"
+            required
+            onChange={onChange}
+            value={question.QuestionnaireId}>
+            {questionnaires.map((q) => (
+              <option key={q.id} value={q.id}>
+                {q.title}
+              </option>
+            ))}
+          </select>
+          {error?.errorMessagesHTMLFor?.('proQuestionnaireIdmpt')}
+        </div>
         <div className="mb-3">
           <label htmlFor="prompt">prompt</label>
           <input

--- a/client/src/Questions/QuestionsList.js
+++ b/client/src/Questions/QuestionsList.js
@@ -1,17 +1,20 @@
-import { Link } from 'react-router-dom';
+import { Link, useParams } from 'react-router-dom';
 
-// import './ResourcesList.scss';
 import { useAuthContext } from '../AuthContext';
 import { useEffect, useState } from 'react';
 import Api from '../Api';
 
 function QuestionsList() {
+  const { id: questionnaireId } = useParams();
   const { user } = useAuthContext();
   const [questions, setQuestions] = useState([]);
 
-  useEffect(function () {
-    Api.questions.index().then((response) => setQuestions(response.data));
-  }, []);
+  useEffect(
+    function () {
+      Api.questions.index(questionnaireId).then((response) => setQuestions(response.data));
+    },
+    [questionnaireId]
+  );
 
   async function onDelete(question) {
     if (window.confirm(`Are you sure you wish to delete "${question.prompt}"?`)) {
@@ -27,7 +30,7 @@ function QuestionsList() {
       <div className="container">
         {user && (
           <div className="mb-3">
-            <Link className="btn btn-primary" to="/questions/new">
+            <Link className="btn btn-primary" to={`/questions/new${questionnaireId ? `?QuestionnaireId=${questionnaireId}` : ''}`}>
               New Question
             </Link>
           </div>

--- a/routes/api/questions.js
+++ b/routes/api/questions.js
@@ -6,14 +6,22 @@ const router = express.Router();
 const models = require('../../models');
 
 router.get('/', async (req, res) => {
-  const records = await models.Question.findAll({ order: [['prompt', 'ASC']] });
+  const options = {
+    order: [['prompt', 'ASC']],
+  };
+  if (req.query.questionnaireId) {
+    options.where = {
+      QuestionnaireId: req.query.questionnaireId,
+    };
+  }
+  const records = await models.Question.findAll(options);
   res.json(records.map((record) => record.toJSON()));
 });
 
 router.post('/', async (req, res) => {
   try {
     const record = await models.Question.create(
-      _.pick(req.body, ['prompt', 'answer_type', 'questionnaire_type', 'step'])
+      _.pick(req.body, ['QuestionnaireId', 'prompt', 'answer_type', 'questionnaire_type', 'step'])
     );
     res.status(HttpStatus.CREATED).json(record.toJSON());
   } catch (error) {
@@ -40,9 +48,7 @@ router.get('/:id', async (req, res) => {
 router.patch('/:id', async (req, res) => {
   const record = await models.Question.findByPk(req.params.id);
   if (record) {
-    await record.update(
-      _.pick(req.body, ['prompt', 'answer_type', 'questionnaire_type', 'step'])
-    );
+    await record.update(_.pick(req.body, ['QuestionnaireId', 'prompt', 'answer_type', 'questionnaire_type', 'step']));
     res.json(record.toJSON());
   } else {
     res.status(HttpStatus.NOT_FOUND).end();


### PR DESCRIPTION
Ok team, time to see some more new fun stuff... in this PR, I show how we can display/edit the _association_ betwen the Questionnaire/Question models...

So far, we've been implementing CRUD (Create, Retrieve, Update, Delete) actions on the models individually, in isolation... but the real power of the SQL database shines when we start managing _associations_ between models.

If you look at the Questionnaire and Question model files, you'll notice that there is an associate function that connects the two together... we say that a Questionnaire HAS MANY Question, and a Question BELONGS TO a Questionnaire...

I'll now comment in the code in this PR to show how this gets used in the back-end API and in the front-end SPA...